### PR TITLE
docs: add deployed application link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,7 @@ The project includes a key Cloud Function for Firebase that integrates with the 
 -   **Purpose**: This function automatically generates a vector embedding for a book's notes whenever the notes are added or updated in Firestore.
 -   **Trigger**: The function is triggered by `onWrite` events on documents in the `/users/{userId}/books/{bookId}` collection. For example, a real document path could be `/users/123/books/456`.
 -   **Details**: When a book's `notes` field is modified, the function uses a Genkit embedder to create a 768-dimensional vector embedding of the notes. This embedding is then stored in the `embedding` field of the same document, enabling vector-based similarity searches.
+
+## Deployed Application
+
+You can access the deployed application here: [https://studio--bookwise-7k4b9.us-central1.hosted.app](https://studio--bookwise-7k4b9.us-central1.hosted.app)


### PR DESCRIPTION
This pull request updates the `README.md` file to include a link to the deployed application for easier access.

* Documentation update:
  * Added a "Deployed Application" section with a link to the live application: [https://studio--bookwise-7k4b9.us-central1.hosted.app](https://studio--bookwise-7k4b9.us-central1.hosted.app) (`README.md`, [README.mdR93-R96](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R93-R96)).